### PR TITLE
get events in a time interval

### DIFF
--- a/Sharpino.Lib/Cache.fs
+++ b/Sharpino.Lib/Cache.fs
@@ -5,8 +5,11 @@ open Sharpino.Core
 open System.Runtime.CompilerServices
 open System.Collections
 open FSharp.Core
+open log4net
+open log4net.Config
 
 module Cache =
+    let log = LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType)
     type EventCache<'A when 'A: equality> private () =
         let dic = Generic.Dictionary<'A * List<Event<'A>>, Result<'A, string>>()
         let queue = Generic.Queue<'A * List<Event<'A>>>()
@@ -24,6 +27,7 @@ module Cache =
                 ()
             with :? _ as e -> 
                 printf "error: cache is doing something wrong. Resetting. %A\n" e   
+                log.Error(sprintf "error: cache is doing something wrong. Resetting. %A\n" e)    
                 dic.Clear()
                 queue.Clear()
                 ()
@@ -65,6 +69,7 @@ module Cache =
                 ()
             with :? _ as e -> 
                 printf "error: cache is doing something wrong. Resetting. %A\n" e   
+                log.Error(sprintf "error: cache is doing something wrong. Resetting. %A\n" e)    
                 dic.Clear()
                 queue.Clear()
                 ()
@@ -100,8 +105,8 @@ module Cache =
                     dic.Remove removed |> ignore
                 ()
             with :? _ as e -> 
-                printf "warning: cache is doing something wrong %A\n" e
-                printf "resetting cache of snapthots"
+                printf "error: cache is doing something wrong. Resetting. %A\n" e
+                log.Error(sprintf "error: cache is doing something wrong. Resetting. %A\n" e)    
                 dic.Clear()
                 queue.Clear()
                 ()

--- a/Sharpino.Lib/EventStoreStorage.fs
+++ b/Sharpino.Lib/EventStoreStorage.fs
@@ -113,8 +113,10 @@ module EventStore =
                 |>> (fun e -> (e.OriginalEventNumber.ToUInt64(), Encoding.UTF8.GetString(e.Event.Data.ToArray()))) 
                 |> List.ofSeq
 
-            // can't use in an efficient way the query api of eventstore, so we have to read all the events and then filter them
+            // there are two issues in this function:
+            // 1. can't use in an efficient way the query api of eventstore, so we have to read all the events and then filter them
             // https://stackoverflow.com/questions/74829893/eventstore-read-specific-time-frame-from-stream
+            // 2. it will not survive after a migration because the timestamps will be different
             member this.ConsumeEventsInATimeInterval version name dateFrom dateTo =
                 log.Debug (sprintf "ConsumeEventsInATimeInterval %s %s %A %A" version name dateFrom dateTo)
                 let streamName = "events" + version + name

--- a/Sharpino.Lib/MemoryStorage.fs
+++ b/Sharpino.Lib/MemoryStorage.fs
@@ -213,6 +213,8 @@ module MemoryStorage =
                     snapshots_dic.[version].[name]
                     |> List.tryLast
                     |>> (fun x -> x.Id)
+
+            // Issue: it will not survive after a version migration because the timestamps will be different
             member this.GetEventsInATimeInterval(version: version) (name: Name) (dateFrom: DateTime) (dateTo: DateTime): List<int * 'E> = 
                 log.Debug (sprintf "GetEventsInATimeInterval %s %s %A %A" version name dateFrom dateTo)
                 if (events_dic.ContainsKey version |> not) || (events_dic.[version].ContainsKey name |> not) then

--- a/Sharpino.Lib/Storage.fs
+++ b/Sharpino.Lib/Storage.fs
@@ -32,6 +32,7 @@ module Storage =
         abstract member AddSnapshot: UInt64 -> version -> Json -> Name -> unit
         abstract member ConsumeEventsFromPosition: version -> Name -> uint64 -> (uint64 * Json) list
         abstract member TryGetLastSnapshot: version -> Name -> Option<UInt64 * Json>
+        abstract member ConsumeEventsInATimeInterval: version -> Name -> DateTime -> DateTime -> List<uint64 * Json>
 
     type IStorage =
         abstract member Reset: version -> Name -> unit

--- a/Sharpino.Sample/AppVersions.fs
+++ b/Sharpino.Sample/AppVersions.fs
@@ -17,6 +17,8 @@ open Sharpino.Sample.EventStoreApp
 open Sharpino.Sample.Todos.TodoEvents
 open Sharpino.Sample.Categories.CategoriesEvents
 open Sharpino.Sample.Tags.TagsEvents
+open Sharpino.Sample.Entities.TodosReport
+
 open Sharpino.Sample
 open FSharpPlus.Operators
 open Newtonsoft.Json
@@ -102,6 +104,8 @@ module AppVersions =
             addTag:             Tag -> Result<unit, string>
             removeTag:          Guid -> Result<unit, string>
             getAllTags:         unit -> Result<List<Tag>, string>
+            todoReport:         DateTime -> DateTime -> TodosEvents
+
         }
 
     [<CurrentVersion>]
@@ -109,7 +113,7 @@ module AppVersions =
         {
             _migrator  =        currentPgApp.Migrate |> Some
             _forceStateUpdate = None
-            // addevents is specifically used for testing to check what happens if adding twice the same event (in the sense that the evolve will be able to skip inconsistent events)
+            // addevents is specifically used test what happens if adding twice the same event (in the sense that the evolve will be able to skip inconsistent events)
             _reset =            fun () -> resetDb storage
             _addEvents =        fun (version, e: List<string>, name ) -> 
                                     let deser = e |>> (fun x -> jsonSerializer.Deserialize x |> Result.get)
@@ -124,6 +128,7 @@ module AppVersions =
             addTag =            currentPgApp.AddTag 
             removeTag =         currentPgApp.RemoveTag
             getAllTags =        currentPgApp.GetAllTags
+            todoReport =        currentPgApp.TodoReport
         }
 
     [<UpgradedVersion>]
@@ -145,6 +150,7 @@ module AppVersions =
             addTag =            upgradedPgApp.AddTag
             removeTag =         upgradedPgApp.removeTag
             getAllTags =        upgradedPgApp.GetAllTags
+            todoReport =        upgradedPgApp.TodoReport
         }
 
 
@@ -167,6 +173,7 @@ module AppVersions =
             addTag =            currentMemApp.AddTag 
             removeTag =         currentMemApp.RemoveTag
             getAllTags =        currentMemApp.GetAllTags
+            todoReport =        currentMemApp.TodoReport
         }
 
     [<UpgradedVersion>]
@@ -188,6 +195,7 @@ module AppVersions =
             addTag =            upgradedMemApp.AddTag
             removeTag =         upgradedMemApp.removeTag
             getAllTags =        upgradedMemApp.GetAllTags
+            todoReport =        upgradedMemApp.TodoReport
         }
 
     [<CurrentVersion>]
@@ -216,4 +224,5 @@ module AppVersions =
             addTag =            evStoreApp.AddTag
             removeTag =         evStoreApp.RemoveTag
             getAllTags =        evStoreApp.GetAllTags
+            todoReport =        evStoreApp.TodoReport
         }


### PR DESCRIPTION
ability to get events in a time interval (not suitable after a version migration because of resetting timestamps). Can't be efficient for eventstoreDB atm.